### PR TITLE
Update main.tex

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -49,6 +49,7 @@
     % sortcites=false, %不排序
     sortlocale=zh__pinyin, %按拼音排序
     gbalign=left, %对齐方式，同时显示序号
+    gbcitelabel=quanjiao %引用全角括号及标点
 ]{biblatex} % 参考文献管理
 \usepackage{amsmath, amssymb, amsthm, amsfonts, mathtools} % 数学环境
 \usepackage{tikz} % tikz绘图


### PR DESCRIPTION
你好，我在我的texlive2024,编译环境为latexmk(xelatex)中编译后出现以下警告
![屏幕截图 2024-04-07 005309](https://github.com/Nanqiang01/CUFE_Graduate_Thesis_Template/assets/76762845/efb598b5-2055-4647-a386-e070672e80dc)
经过我的搜索后发现[同样的的问题](https://github.com/hushidong/biblatex-gb7714-2015/issues/166)也出现在引用的括号中如下图
![image](https://github.com/Nanqiang01/CUFE_Graduate_Thesis_Template/assets/76762845/a323e86f-5e36-4c32-825e-53d29dc991bb)
其并不符合学校给出的word文档中使用全角符号的规范如下图
![image](https://github.com/Nanqiang01/CUFE_Graduate_Thesis_Template/assets/76762845/6a72f6bc-1361-4fda-9dc2-3a3a600f264e)
使用[同样的的问题](https://github.com/hushidong/biblatex-gb7714-2015/issues/166)中的解决方案添加gbcitelabel=quanjiao后显示如下图，应该没用问题
![image](https://github.com/Nanqiang01/CUFE_Graduate_Thesis_Template/assets/76762845/64cd45a7-23ae-4554-8420-545ae56ee7f0)
还有就是请问你能开放仓库的issue吗，非常感谢你提供的latex模板，我最近也在赶毕业论文，应该会高强度使用这个模板，我也想在发现问题后及时提交，及时帮助更多使用这个模板的同学

